### PR TITLE
ci: avoid publishing images from pull requests

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -3,6 +3,8 @@ name: Docker Build
 on:
   push:
     branches: [main, dev]
+  pull_request:
+    branches: [main, dev]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/publish-images.yml
+++ b/.github/workflows/publish-images.yml
@@ -3,8 +3,6 @@ name: Publish Docker images to GHCR
 on:
   push:
     branches: [main, dev]
-  pull_request:
-    branches: [main, dev]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Builds container images for pull requests without attempting to publish them to GHCR.